### PR TITLE
fixed BetterPing.cs compiling error

### DIFF
--- a/MCGalaxy/Plugins/BetterPing.cs
+++ b/MCGalaxy/Plugins/BetterPing.cs
@@ -7,7 +7,7 @@ using System;
 using MCGalaxy.Events.PlayerEvents;
 
 namespace MCGalaxy {
-	public class BetterPing : Plugin_Simple {
+	public class BetterPing : Plugin {
 		public override string creator { get { return "Venk"; } }
 		public override string MCGalaxy_Version { get { return "1.9.1.3"; } }
 		public override string name { get { return "BetterPing"; } }


### PR DESCRIPTION
Changed on line 10 plugin_simple to just plugin as when compiling with plugin_simple now creates error when compiling

![screenshot](https://user-images.githubusercontent.com/72346428/114188157-d9f56380-9916-11eb-8ba5-5aec767adcfc.png)
